### PR TITLE
stop using alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.0.0-alpine
+FROM node:10.0.0
 
 ENV NPM_VERSION 6.0.0
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # node10npm6
-A temporary Dockerfile for node:10.0.0-alpine that adds npm 6.0.0.
+A temporary Dockerfile for node:10.0.0 that adds npm 6.0.0.


### PR DESCRIPTION
We need 'git' in my particular use-case, which is available in the main-line build, but not `-alpine`.